### PR TITLE
feat(application): define application ports for repositories, UnitOfW…

### DIFF
--- a/app/src/application/__init__.py
+++ b/app/src/application/__init__.py
@@ -1,0 +1,23 @@
+"""Application layer exports."""
+
+from application.ports import (
+    Clock,
+    JWTProvider,
+    PasswordHasher,
+    ProjectRepository,
+    TaskRepository,
+    TokenPair,
+    UnitOfWork,
+    WorkspaceRepository,
+)
+
+__all__ = [
+    "Clock",
+    "JWTProvider",
+    "PasswordHasher",
+    "ProjectRepository",
+    "TaskRepository",
+    "TokenPair",
+    "UnitOfWork",
+    "WorkspaceRepository",
+]

--- a/app/src/application/ports/__init__.py
+++ b/app/src/application/ports/__init__.py
@@ -1,0 +1,21 @@
+"""Application ports exposed to outer layers."""
+
+from application.ports.repositories import (
+    ProjectRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from application.ports.security import JWTProvider, PasswordHasher, TokenPair
+from application.ports.time import Clock
+from application.ports.unit_of_work import UnitOfWork
+
+__all__ = [
+    "Clock",
+    "JWTProvider",
+    "PasswordHasher",
+    "ProjectRepository",
+    "TaskRepository",
+    "TokenPair",
+    "UnitOfWork",
+    "WorkspaceRepository",
+]

--- a/app/src/application/ports/repositories.py
+++ b/app/src/application/ports/repositories.py
@@ -1,0 +1,65 @@
+"""Repository ports for application use cases."""
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from domain import (
+    Project,
+    ProjectId,
+    Task,
+    TaskId,
+    UserId,
+    Workspace,
+    WorkspaceId,
+)
+
+
+@runtime_checkable
+class TaskRepository(Protocol):
+    """Persistence contract for task aggregates."""
+
+    def add(self, task: Task) -> None:
+        """Persist a new task."""
+
+    def get_by_id(self, task_id: TaskId) -> Task | None:
+        """Load a task by its identifier."""
+
+    def list_by_project(self, project_id: ProjectId) -> Sequence[Task]:
+        """List tasks that belong to a project."""
+
+    def remove(self, task: Task) -> None:
+        """Delete a task from persistence."""
+
+
+@runtime_checkable
+class ProjectRepository(Protocol):
+    """Persistence contract for project aggregates."""
+
+    def add(self, project: Project) -> None:
+        """Persist a new project."""
+
+    def get_by_id(self, project_id: ProjectId) -> Project | None:
+        """Load a project by its identifier."""
+
+    def list_by_workspace(self, workspace_id: WorkspaceId) -> Sequence[Project]:
+        """List projects that belong to a workspace."""
+
+    def remove(self, project: Project) -> None:
+        """Delete a project from persistence."""
+
+
+@runtime_checkable
+class WorkspaceRepository(Protocol):
+    """Persistence contract for workspace aggregates."""
+
+    def add(self, workspace: Workspace) -> None:
+        """Persist a new workspace."""
+
+    def get_by_id(self, workspace_id: WorkspaceId) -> Workspace | None:
+        """Load a workspace by its identifier."""
+
+    def list_by_user(self, user_id: UserId) -> Sequence[Workspace]:
+        """List workspaces visible to a user."""
+
+    def remove(self, workspace: Workspace) -> None:
+        """Delete a workspace from persistence."""

--- a/app/src/application/ports/security.py
+++ b/app/src/application/ports/security.py
@@ -1,0 +1,40 @@
+"""Security-related ports for the application layer."""
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from domain import UserId
+
+
+@dataclass(frozen=True, slots=True)
+class TokenPair:
+    """Token payload returned by authentication use cases."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+@runtime_checkable
+class PasswordHasher(Protocol):
+    """Password hashing contract."""
+
+    def hash(self, plain_password: str) -> str:
+        """Hash a plain text password."""
+
+    def verify(self, plain_password: str, password_hash: str) -> bool:
+        """Verify that a plain text password matches a stored hash."""
+
+
+@runtime_checkable
+class JWTProvider(Protocol):
+    """JWT creation and parsing contract."""
+
+    def issue_tokens(self, *, subject: UserId) -> TokenPair:
+        """Create access and refresh tokens for a subject."""
+
+    def refresh_access_token(self, refresh_token: str) -> str:
+        """Create a new access token from a refresh token."""
+
+    def decode_subject(self, token: str) -> UserId:
+        """Decode a token and return its subject identifier."""

--- a/app/src/application/ports/time.py
+++ b/app/src/application/ports/time.py
@@ -1,0 +1,12 @@
+"""Time-related ports for the application layer."""
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """Provides the current time to use cases."""
+
+    def now(self) -> datetime:
+        """Return the current datetime."""

--- a/app/src/application/ports/unit_of_work.py
+++ b/app/src/application/ports/unit_of_work.py
@@ -1,0 +1,36 @@
+"""Unit of work port for transaction boundaries."""
+
+from types import TracebackType
+from typing import Protocol, Self, runtime_checkable
+
+from application.ports.repositories import (
+    ProjectRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+
+
+@runtime_checkable
+class UnitOfWork(Protocol):
+    """Coordinates repositories and persistence boundaries for a use case."""
+
+    tasks: TaskRepository
+    projects: ProjectRepository
+    workspaces: WorkspaceRepository
+
+    def __enter__(self) -> Self:
+        """Open the transactional boundary."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the transactional boundary."""
+
+    def commit(self) -> None:
+        """Persist pending changes."""
+
+    def rollback(self) -> None:
+        """Discard pending changes."""

--- a/tests/unit/application/test_ports.py
+++ b/tests/unit/application/test_ports.py
@@ -1,0 +1,214 @@
+from datetime import UTC, datetime
+
+from application import (
+    Clock,
+    JWTProvider,
+    PasswordHasher,
+    ProjectRepository,
+    TaskRepository,
+    TokenPair,
+    UnitOfWork,
+    WorkspaceRepository,
+)
+from domain import (
+    Project,
+    ProjectId,
+    Task,
+    TaskId,
+    UserId,
+    Workspace,
+    WorkspaceId,
+)
+
+
+def build_workspace(*, owner_id: UserId | None = None) -> Workspace:
+    return Workspace(
+        id=WorkspaceId.new(),
+        name="Engineering",
+        owner_id=owner_id or UserId.new(),
+    )
+
+
+def build_project(*, workspace_id: WorkspaceId) -> Project:
+    return Project(
+        id=ProjectId.new(),
+        workspace_id=workspace_id,
+        name="Backend API",
+    )
+
+
+def build_task(*, project_id: ProjectId, created_by: UserId) -> Task:
+    return Task(
+        id=TaskId.new(),
+        project_id=project_id,
+        title="Define application ports",
+        created_by=created_by,
+    )
+
+
+class InMemoryTaskRepository:
+    def __init__(self) -> None:
+        self._tasks: dict[TaskId, Task] = {}
+
+    def add(self, task: Task) -> None:
+        self._tasks[task.id] = task
+
+    def get_by_id(self, task_id: TaskId) -> Task | None:
+        return self._tasks.get(task_id)
+
+    def list_by_project(self, project_id: ProjectId) -> list[Task]:
+        return [task for task in self._tasks.values() if task.project_id == project_id]
+
+    def remove(self, task: Task) -> None:
+        self._tasks.pop(task.id, None)
+
+
+class InMemoryProjectRepository:
+    def __init__(self) -> None:
+        self._projects: dict[ProjectId, Project] = {}
+
+    def add(self, project: Project) -> None:
+        self._projects[project.id] = project
+
+    def get_by_id(self, project_id: ProjectId) -> Project | None:
+        return self._projects.get(project_id)
+
+    def list_by_workspace(self, workspace_id: WorkspaceId) -> list[Project]:
+        return [
+            project
+            for project in self._projects.values()
+            if project.workspace_id == workspace_id
+        ]
+
+    def remove(self, project: Project) -> None:
+        self._projects.pop(project.id, None)
+
+
+class InMemoryWorkspaceRepository:
+    def __init__(self) -> None:
+        self._workspaces: dict[WorkspaceId, Workspace] = {}
+
+    def add(self, workspace: Workspace) -> None:
+        self._workspaces[workspace.id] = workspace
+
+    def get_by_id(self, workspace_id: WorkspaceId) -> Workspace | None:
+        return self._workspaces.get(workspace_id)
+
+    def list_by_user(self, user_id: UserId) -> list[Workspace]:
+        return [
+            workspace
+            for workspace in self._workspaces.values()
+            if workspace.owner_id == user_id
+        ]
+
+    def remove(self, workspace: Workspace) -> None:
+        self._workspaces.pop(workspace.id, None)
+
+
+class FixedClock:
+    def __init__(self, current_time: datetime) -> None:
+        self._current_time = current_time
+
+    def now(self) -> datetime:
+        return self._current_time
+
+
+class StubPasswordHasher:
+    def hash(self, plain_password: str) -> str:
+        return f"hashed::{plain_password}"
+
+    def verify(self, plain_password: str, password_hash: str) -> bool:
+        return password_hash == self.hash(plain_password)
+
+
+class StubJWTProvider:
+    def __init__(self, subject: UserId) -> None:
+        self._subject = subject
+
+    def issue_tokens(self, *, subject: UserId) -> TokenPair:
+        return TokenPair(
+            access_token=f"access::{subject.value}",
+            refresh_token=f"refresh::{subject.value}",
+        )
+
+    def refresh_access_token(self, refresh_token: str) -> str:
+        return refresh_token.replace("refresh::", "access::", 1)
+
+    def decode_subject(self, token: str) -> UserId:
+        return self._subject
+
+
+class FakeUnitOfWork:
+    def __init__(
+        self,
+        *,
+        tasks: TaskRepository,
+        projects: ProjectRepository,
+        workspaces: WorkspaceRepository,
+    ) -> None:
+        self.tasks = tasks
+        self.projects = projects
+        self.workspaces = workspaces
+        self.committed = False
+        self.rolled_back = False
+
+    def __enter__(self) -> "FakeUnitOfWork":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None:
+        if exc is not None:
+            self.rollback()
+        return None
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+def test_application_ports_define_use_case_boundaries() -> None:
+    owner_id = UserId.new()
+    workspace = build_workspace(owner_id=owner_id)
+    project = build_project(workspace_id=workspace.id)
+    task = build_task(project_id=project.id, created_by=owner_id)
+
+    task_repository = InMemoryTaskRepository()
+    project_repository = InMemoryProjectRepository()
+    workspace_repository = InMemoryWorkspaceRepository()
+    fixed_clock = FixedClock(datetime(2026, 4, 9, 12, 0, tzinfo=UTC))
+    password_hasher = StubPasswordHasher()
+    jwt_provider = StubJWTProvider(owner_id)
+    unit_of_work = FakeUnitOfWork(
+        tasks=task_repository,
+        projects=project_repository,
+        workspaces=workspace_repository,
+    )
+
+    assert isinstance(task_repository, TaskRepository)
+    assert isinstance(project_repository, ProjectRepository)
+    assert isinstance(workspace_repository, WorkspaceRepository)
+    assert isinstance(fixed_clock, Clock)
+    assert isinstance(password_hasher, PasswordHasher)
+    assert isinstance(jwt_provider, JWTProvider)
+    assert isinstance(unit_of_work, UnitOfWork)
+
+    with unit_of_work as active_unit_of_work:
+        active_unit_of_work.workspaces.add(workspace)
+        active_unit_of_work.projects.add(project)
+        active_unit_of_work.tasks.add(task)
+        active_unit_of_work.commit()
+
+    issued_tokens = jwt_provider.issue_tokens(subject=owner_id)
+
+    assert unit_of_work.committed is True
+    assert fixed_clock.now() == datetime(2026, 4, 9, 12, 0, tzinfo=UTC)
+    assert password_hasher.verify("secret", password_hasher.hash("secret")) is True
+    assert issued_tokens.token_type == "bearer"
+    assert jwt_provider.refresh_access_token(issued_tokens.refresh_token).startswith(
+        "access::"
+    )
+    assert jwt_provider.decode_subject(issued_tokens.access_token) == owner_id
+    assert task_repository.get_by_id(task.id) == task
+    assert project_repository.list_by_workspace(workspace.id) == [project]
+    assert workspace_repository.list_by_user(owner_id) == [workspace]


### PR DESCRIPTION
This PR introduces the main application ports required by Clean Architecture. It defines Protocol-based interfaces for TaskRepository, ProjectRepository, WorkspaceRepository, UnitOfWork, Clock, PasswordHasher, and JWTProvider. These contracts establish clear boundaries for the infrastructure layer to implement, without introducing any dependencies on infrastructure or presentation code. A minimal test validates the interfaces and their intended usage.